### PR TITLE
Add script needed to publish epx-pop to AWS CloudArtifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 epx-pop is a Python package for interacting with [FRED](https://docs.epistemix.com/projects/language/en/latest/) synthetic populations.
 
-
 ## Requirements
 
 In order to use the functions and classes in this package, you will need the following Python packages installed:
 
 - [pandas](https://pandas.pydata.org)
-
 
 ## Installation
 
@@ -103,3 +101,11 @@ page](https://github.com/Epistemix-com/epx-pop) click:
 
 Name the release something like 'epx-pop v1.0.0', and copy the release notes
 from the `CHANGELOG.md` into the description box.
+
+### Packaging
+
+To publish a new version of `epx-pop` to AWS CodeArtifact run the script
+
+```shell
+scripts/codeartifact-upload
+```

--- a/scripts/codeartifact-upload
+++ b/scripts/codeartifact-upload
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+set -e
+
+pip install twine
+
+echo "Building distribution"
+python -m build
+
+echo "Publishing wheel to AWS CodeArtifact"
+aws codeartifact login --tool twine --domain epistemix --repository epistemix-engineering
+
+twine upload --repository codeartifact dist/*
+
+echo "Success: epx-pop published to AWS CodeArtifact"


### PR DESCRIPTION
epx-pop is arguably legacy code at this point, and should be replaced with functionality in epx-exec. However, some internal packages (including COVID19-data which is required for autocal) were configured to install epx-pop from JFrog previously. Publishing to CodeArtifact allows us to continue using those packages in the same way as we used to when installing on Cloud Runner.