### PR TITLE
Added pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel", "pip"]
+build-backend = "setuptools.build_meta"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "pip"]
+requires = ["setuptools>=59.6.0", "wheel", "pip"]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Rectifies issue where pip cannot be found in the virtual environment spawned by `python3 -m build`.